### PR TITLE
Fix  #22 , release image data for memory leaking

### DIFF
--- a/addon_ground_truth_generation.py
+++ b/addon_ground_truth_generation.py
@@ -226,6 +226,7 @@ def load_file_data_to_numpy(scene, tmp_file_path, data_map):
         return None
     out_data = bpy.data.images.load(tmp_file_path)
     pixels_numpy = np.array(out_data.pixels[:])
+    bpy.data.images.remove(out_data)
     res_x, res_y = get_scene_resolution(scene)
     pixels_numpy.resize((res_y, res_x, 4)) # Numpy works with (y, x, channels)
     pixels_numpy = np.flip(pixels_numpy, 0) # flip vertically (in Blender y in the image points up instead of down)


### PR DESCRIPTION
I try to release image data in load_file_data_to_numpy,

```python
    pixels_numpy = np.array(out_data.pixels[:])
    bpy.data.images.remove(out_data)
    res_x, res_y = get_scene_resolution(scene)
```
and run 9999 render.
It seems work for me, all image and npz success created, not mem increases or linux killed happend;
but virt and res still increases, blender stop after all render.